### PR TITLE
feat: 회원가입 페이지 UI 구현 및 auth 입력 컴포넌트/타입 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postcss": "^8.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.54.2",
     "react-router-dom": "^6.30.0",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^3.4.17"

--- a/src/components/auth/EmailInput.tsx
+++ b/src/components/auth/EmailInput.tsx
@@ -1,20 +1,15 @@
 import { useId } from 'react';
-import type { FieldErrors, Path, UseFormRegister } from 'react-hook-form';
+
+import type { AuthFormInputProps } from '@/types/auth.types';
 
 import Input from '../input/Input';
 import InputWrapper from '../input/InputWrapper';
-
-interface EmailInputProps<T extends Record<string, any>> {
-  register: UseFormRegister<T>;
-  errors: FieldErrors<T>;
-  name: Path<T>;
-}
 
 const EmailInput = <T extends Record<string, any>>({
   register,
   errors,
   name,
-}: EmailInputProps<T>) => {
+}: AuthFormInputProps<T>) => {
   const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const id = useId();
 

--- a/src/components/auth/EmailInput.tsx
+++ b/src/components/auth/EmailInput.tsx
@@ -1,0 +1,44 @@
+import { useId } from 'react';
+import type { FieldErrors, Path, UseFormRegister } from 'react-hook-form';
+
+import Input from '../input/Input';
+import InputWrapper from '../input/InputWrapper';
+
+interface EmailInputProps<T extends Record<string, any>> {
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  name: Path<T>;
+}
+
+const EmailInput = <T extends Record<string, any>>({
+  register,
+  errors,
+  name,
+}: EmailInputProps<T>) => {
+  const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const id = useId();
+
+  return (
+    <InputWrapper
+      label='이메일'
+      htmlFor={id}
+      error={!!errors[name]}
+      errorMessage={errors[name]?.message as string}
+    >
+      <Input
+        type='email'
+        id={id}
+        placeholder='이메일을 입력해 주세요'
+        {...register(name, {
+          required: '이메일을 입력해 주세요',
+          pattern: {
+            value: EMAIL_REGEX,
+            message: '이메일 형식으로 입력해 주세요',
+          },
+        })}
+      />
+    </InputWrapper>
+  );
+};
+
+export default EmailInput;

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,47 @@
+import { useId } from 'react';
+import type { FieldErrors, Path, UseFormRegister } from 'react-hook-form';
+
+import Input from '../input/Input';
+import InputWrapper from '../input/InputWrapper';
+
+interface PasswordInputProps<T extends Record<string, any>> {
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  name: Path<T>;
+}
+
+const PasswordInput = <T extends Record<string, any>>({
+  register,
+  errors,
+  name,
+}: PasswordInputProps<T>) => {
+  const id = useId();
+
+  return (
+    <InputWrapper
+      label='비밀번호'
+      htmlFor={id}
+      error={!!errors[name]}
+      errorMessage={errors[name]?.message as string}
+    >
+      <Input
+        type='password'
+        id={id}
+        placeholder='비밀번호를 입력해 주세요'
+        {...register(name, {
+          required: '비밀번호를 입력해 주세요',
+          minLength: {
+            value: 8,
+            message: '비밀번호는 8자 이상으로 입력해 주세요',
+          },
+          maxLength: {
+            value: 16,
+            message: '비밀번호는 16자 이하로 입력해 주세요',
+          },
+        })}
+      />
+    </InputWrapper>
+  );
+};
+
+export default PasswordInput;

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,20 +1,15 @@
 import { useId } from 'react';
-import type { FieldErrors, Path, UseFormRegister } from 'react-hook-form';
+
+import type { AuthFormInputProps } from '@/types/auth.types';
 
 import Input from '../input/Input';
 import InputWrapper from '../input/InputWrapper';
-
-interface PasswordInputProps<T extends Record<string, any>> {
-  register: UseFormRegister<T>;
-  errors: FieldErrors<T>;
-  name: Path<T>;
-}
 
 const PasswordInput = <T extends Record<string, any>>({
   register,
   errors,
   name,
-}: PasswordInputProps<T>) => {
+}: AuthFormInputProps<T>) => {
   const id = useId();
 
   return (

--- a/src/components/input/InputWrapper.tsx
+++ b/src/components/input/InputWrapper.tsx
@@ -37,14 +37,14 @@ const InputWrapper = ({
       {label && (
         <label
           htmlFor={htmlFor}
-          className='text-xs font-medium leading-none text-gray-500'
+          className='text-sm font-medium leading-none text-gray-500'
         >
           {label}
         </label>
       )}
       {children}
       {error && errorMessage && (
-        <span className='mt-1 block text-xs font-medium leading-[1.7] text-red'>
+        <span className='block text-xs font-medium leading-none text-red'>
           {errorMessage}
         </span>
       )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,17 @@ import './index.css';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
+import SignUpPage from './pages/auth/SignUp.tsx';
 import HomePage from './pages/Home.tsx';
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <HomePage />,
+  },
+  {
+    path: '/signup',
+    element: <SignUpPage />,
   },
 ]);
 

--- a/src/pages/auth/AuthLayout.tsx
+++ b/src/pages/auth/AuthLayout.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
+
+interface IAuthLayoutProps extends PropsWithChildren {}
+
+const AuthLayout = ({ children }: IAuthLayoutProps) => {
+  return (
+    <div className='flex h-dvh'>
+      <div className='hidden bg-slate-950 p-10 lg:block lg:flex-1'>
+        <h1>
+          <Link to='/' className='text-2xl font-bold text-white'>
+            이사대학
+          </Link>
+        </h1>
+      </div>
+      <div className='flex flex-1 items-center'>
+        <div className='mx-auto box-content w-full max-w-[360px] p-6'>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AuthLayout;

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -2,19 +2,19 @@ import { useId } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
+import EmailInput from '@/components/auth/EmailInput';
 import Button from '@/components/button/Button';
 import Input from '@/components/input/Input';
 import InputWrapper from '@/components/input/InputWrapper';
 
 import AuthLayout from './AuthLayout';
 
-type SignUpForm = {
+export type SignUpForm = {
   email: string;
   password: string;
 };
 
 const SignUpPage = () => {
-  const emailId = useId();
   const passwordId = useId();
   const {
     register,
@@ -36,25 +36,7 @@ const SignUpPage = () => {
         <div className='mt-8'>
           <form onSubmit={handleSubmit(onSubmit)}>
             <div className='grid gap-4'>
-              <InputWrapper
-                label='이메일'
-                htmlFor={emailId}
-                error={!!errors.email}
-                errorMessage={errors.email?.message}
-              >
-                <Input
-                  type='email'
-                  id={emailId}
-                  placeholder='이메일을 입력해 주세요'
-                  {...register('email', {
-                    required: '이메일을 입력해 주세요',
-                    pattern: {
-                      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                      message: '이메일 형식으로 입력해 주세요',
-                    },
-                  })}
-                />
-              </InputWrapper>
+              <EmailInput register={register} errors={errors} name='email' />
               <InputWrapper
                 label='비밀번호'
                 htmlFor={passwordId}

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -1,16 +1,13 @@
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
+import type { SignUpForm } from '@/types/auth.types';
+
 import EmailInput from '@/components/auth/EmailInput';
 import PasswordInput from '@/components/auth/PasswordInput';
 import Button from '@/components/button/Button';
 
 import AuthLayout from './AuthLayout';
-
-export type SignUpForm = {
-  email: string;
-  password: string;
-};
 
 const SignUpPage = () => {
   const {

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -1,11 +1,9 @@
-import { useId } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
 import EmailInput from '@/components/auth/EmailInput';
+import PasswordInput from '@/components/auth/PasswordInput';
 import Button from '@/components/button/Button';
-import Input from '@/components/input/Input';
-import InputWrapper from '@/components/input/InputWrapper';
 
 import AuthLayout from './AuthLayout';
 
@@ -15,7 +13,6 @@ export type SignUpForm = {
 };
 
 const SignUpPage = () => {
-  const passwordId = useId();
   const {
     register,
     handleSubmit,
@@ -37,29 +34,11 @@ const SignUpPage = () => {
           <form onSubmit={handleSubmit(onSubmit)}>
             <div className='grid gap-4'>
               <EmailInput register={register} errors={errors} name='email' />
-              <InputWrapper
-                label='비밀번호'
-                htmlFor={passwordId}
-                error={!!errors.password}
-                errorMessage={errors.password?.message}
-              >
-                <Input
-                  type='password'
-                  id={passwordId}
-                  placeholder='비밀번호를 입력해 주세요'
-                  {...register('password', {
-                    required: '비밀번호를 입력해 주세요',
-                    minLength: {
-                      value: 8,
-                      message: '비밀번호는 8자 이상으로 입력해 주세요',
-                    },
-                    maxLength: {
-                      value: 16,
-                      message: '비밀번호는 16자 이하로 입력해 주세요',
-                    },
-                  })}
-                />
-              </InputWrapper>
+              <PasswordInput
+                register={register}
+                errors={errors}
+                name='password'
+              />
             </div>
             <Button type='submit' disabled={!isValid} className='mt-8'>
               회원가입

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -1,0 +1,11 @@
+import AuthLayout from './AuthLayout';
+
+const SignUpPage = () => {
+  return (
+    <AuthLayout>
+      <div>회원가입</div>
+    </AuthLayout>
+  );
+};
+
+export default SignUpPage;

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -1,9 +1,90 @@
+import { useId } from 'react';
+import type { SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+
+import Button from '@/components/button/Button';
+import Input from '@/components/input/Input';
+import InputWrapper from '@/components/input/InputWrapper';
+
 import AuthLayout from './AuthLayout';
 
+type SignUpForm = {
+  email: string;
+  password: string;
+};
+
 const SignUpPage = () => {
+  const emailId = useId();
+  const passwordId = useId();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<SignUpForm>({ mode: 'onChange' });
+
+  const onSubmit: SubmitHandler<SignUpForm> = (data) => {
+    /**
+     * @TODO 회원가입 로직 구현
+     */
+    console.log(data);
+  };
+
   return (
     <AuthLayout>
-      <div>회원가입</div>
+      <div className='grid'>
+        <h2 className='text-2xl font-bold'>회원가입</h2>
+        <div className='mt-8'>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <div className='grid gap-4'>
+              <InputWrapper
+                label='이메일'
+                htmlFor={emailId}
+                error={!!errors.email}
+                errorMessage={errors.email?.message}
+              >
+                <Input
+                  type='email'
+                  id={emailId}
+                  placeholder='이메일을 입력해 주세요'
+                  {...register('email', {
+                    required: '이메일을 입력해 주세요',
+                    pattern: {
+                      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                      message: '이메일 형식으로 입력해 주세요',
+                    },
+                  })}
+                />
+              </InputWrapper>
+              <InputWrapper
+                label='비밀번호'
+                htmlFor={passwordId}
+                error={!!errors.password}
+                errorMessage={errors.password?.message}
+              >
+                <Input
+                  type='password'
+                  id={passwordId}
+                  placeholder='비밀번호를 입력해 주세요'
+                  {...register('password', {
+                    required: '비밀번호를 입력해 주세요',
+                    minLength: {
+                      value: 8,
+                      message: '비밀번호는 8자 이상으로 입력해 주세요',
+                    },
+                    maxLength: {
+                      value: 16,
+                      message: '비밀번호는 16자 이하로 입력해 주세요',
+                    },
+                  })}
+                />
+              </InputWrapper>
+            </div>
+            <Button type='submit' disabled={!isValid} className='mt-8'>
+              회원가입
+            </Button>
+          </form>
+        </div>
+      </div>
     </AuthLayout>
   );
 };

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -1,0 +1,25 @@
+import type { FieldErrors, Path, UseFormRegister } from 'react-hook-form';
+
+// 인증 관련 폼에서 공통으로 사용하는 필드 (로그인, 회원가입 모두 사용)
+export type AuthFormFields = {
+  email: string;
+  password: string;
+};
+
+// 회원가입 Form 타입
+export type SignUpForm = AuthFormFields;
+// 로그인 Form 타입
+export type LoginForm = AuthFormFields;
+
+/**
+ * 재사용 가능한 form input 컴포넌트용 props 타입 정의
+ *
+ * @property register - react-hook-form의 register 함수
+ * @property errors - 필드별 에러 객체
+ * @property name - 해당 input의 name (폼 필드 key 중 하나)
+ */
+export interface AuthFormInputProps<T extends Record<string, any>> {
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  name: Path<T>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,11 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-hook-form@^7.54.2:
+  version "7.54.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
+  integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 변경 사항
- 회원가입 페이지 퍼블리싱 완료
- 이메일, 비밀번호 입력 필드 각각 EmailInput, PasswordInput 컴포넌트로 분리 (로그인 페이지에서 재사용 가능)
- auth 관련 폼 필드 타입 'types/auth.types.ts' 별도 파일로 정리
- 로그인, 회원가입 페이지 레이아웃 작업 (AuthLayout)