### PR TITLE
feat: 회원가입 결과 토스트 처리 및 성공 시 리디렉션 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-hook-form": "^7.54.2",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.0",
+    "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^3.4.17"
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import './index.css';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 
 import LoginPage from './pages/auth/Login.tsx';
 import SignUpPage from './pages/auth/SignUp.tsx';
@@ -27,5 +28,6 @@ const router = createBrowserRouter([
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <Provider store={store}>
     <RouterProvider router={router} />
+    <ToastContainer />
   </Provider>,
 );

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -54,9 +54,7 @@ const SignUpPage = () => {
 
       if (data.session) {
         toast.success('회원가입이 완료되었습니다!', TOAST_OPTION);
-        setTimeout(() => {
-          navigate('/posts');
-        }, 1000);
+        navigate('/posts');
       } else if (error) {
         handleSignupError(error);
       }

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import type { ToastOptions } from 'react-toastify';
+import { Slide, toast } from 'react-toastify';
 
 import { useSignUpMutation } from '@/services/authApi';
 import type { AuthError } from '@supabase/supabase-js';
@@ -14,14 +16,26 @@ import Button from '@/components/button/Button';
 
 import AuthLayout from './AuthLayout';
 
+const TOAST_OPTION: ToastOptions = {
+  position: 'top-right',
+  autoClose: 3000,
+  hideProgressBar: false,
+  closeOnClick: false,
+  pauseOnHover: true,
+  draggable: true,
+  progress: undefined,
+  theme: 'colored',
+  transition: Slide,
+};
+
 const SignUpPage = () => {
   const {
     register,
     handleSubmit,
-    setError,
     formState: { errors, isValid },
   } = useForm<SignUpForm>({ mode: 'onChange' });
   const [signUp, { isLoading, error }] = useSignUpMutation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (error) {
@@ -34,14 +48,19 @@ const SignUpPage = () => {
       const { data, error } = await signUp(formData);
 
       if (error) {
-        console.error('회원가입 실패', error);
-        setError('email', { message: (error as AuthError).message });
+        console.error('회원가입 실패:', error);
+        toast.error((error as AuthError).message, TOAST_OPTION);
 
         return;
       }
-      console.log('회원가입 성공', data);
+
+      toast.success('회원가입이 완료되었습니다!', TOAST_OPTION);
+      navigate('/');
+
+      return;
     } catch (error) {
-      console.error('회원가입 실패', error);
+      console.error('회원가입 실패:', error);
+      toast.error((error as AuthError).message, TOAST_OPTION);
     }
   };
 
@@ -61,7 +80,7 @@ const SignUpPage = () => {
             </div>
             <Button
               type='submit'
-              disabled={!isValid || !!error}
+              disabled={!isValid}
               isLoading={isLoading}
               className='mt-8'
             >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,6 +2735,13 @@ react-router@6.30.0:
   dependencies:
     "@remix-run/router" "1.23.0"
 
+react-toastify@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.5.tgz#ce4c42d10eeb433988ab2264d3e445c4e9d13313"
+  integrity sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==
+  dependencies:
+    clsx "^2.1.1"
+
 react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 변경 사항
- 회원가입 성공/실패 시 toast 팝업 노출
- 회원가입 성공 시 바로 게시판 리스트 페이지(/posts)로 이동하도록 처리
- 회원가입 실패 처리 함수 별도로 분리