### PR TITLE
feat: token 쿠키 저장 및 access token 자동 갱신 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@reduxjs/toolkit": "^2.6.1",
     "@supabase/supabase-js": "^2.49.3",
     "autoprefixer": "^10.4.21",
+    "js-cookie": "^3.0.5",
     "lottie-react": "^2.4.1",
     "postcss": "^8.5.3",
     "react": "^18.3.1",
@@ -33,6 +34,7 @@
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.13.13",
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lottie-react": "^2.4.1",
     "postcss": "^8.5.3",
     "react": "^18.3.1",
+    "react-cookie": "^8.0.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-redux": "^9.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom';
+
+import useAuth from './hooks/useAuth';
+
+const App = () => {
+  const { useAuthSession } = useAuth();
+  useAuthSession(); // supabase 세션 복원
+
+  return (
+    <main>
+      <Outlet />
+    </main>
+  );
+};
+
+export default App;

--- a/src/constants/auth.constants.ts
+++ b/src/constants/auth.constants.ts
@@ -1,3 +1,5 @@
+export const ACCESS_TOKEN = 'access_token';
+export const REFRESH_TOKEN = 'refresh_token';
 export const REFRESH_TOKEN_EXPIRES_IN = 60 * 60 * 24 * 14; // 2주
 
 export const SIGN_UP_ERROR_MESSAGE: Record<string, string> = {

--- a/src/constants/auth.constants.ts
+++ b/src/constants/auth.constants.ts
@@ -1,3 +1,5 @@
+export const REFRESH_TOKEN_EXPIRES_IN = 60 * 60 * 24 * 14; // 2주
+
 export const SIGN_UP_ERROR_MESSAGE: Record<string, string> = {
   'User already registered': '이미 가입된 이메일입니다.',
   'Invalid email': '유효하지 않은 이메일 형식입니다.',

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
 
+import { ACCESS_TOKEN, REFRESH_TOKEN } from '@/constants/auth.constants';
+
 import supabase from '@/utils/supabase';
 
 export default function useAuth() {
-  const [cookies] = useCookies(['access_token', 'refresh_token']);
+  const [cookies] = useCookies([ACCESS_TOKEN, REFRESH_TOKEN]);
 
   /**
    * 쿠키에서 토큰 꺼내서 supabase 세션 복원
@@ -14,8 +16,8 @@ export default function useAuth() {
   const useAuthSession = () => {
     useEffect(() => {
       const restoreSession = async () => {
-        const access_token = cookies['access_token'];
-        const refresh_token = cookies['refresh_token'];
+        const access_token = cookies[ACCESS_TOKEN];
+        const refresh_token = cookies[REFRESH_TOKEN];
 
         if (access_token && refresh_token) {
           try {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+
+import supabase from '@/utils/supabase';
+
+export default function useAuth() {
+  const [cookies] = useCookies(['access_token', 'refresh_token']);
+
+  /**
+   * 쿠키에서 토큰 꺼내서 supabase 세션 복원
+   * - supabase는 브라우저 메모리만 보고 있고, 쿠키는 직접 확인 안 함
+   */
+
+  const useAuthSession = () => {
+    useEffect(() => {
+      const restoreSession = async () => {
+        const access_token = cookies['access_token'];
+        const refresh_token = cookies['refresh_token'];
+
+        if (access_token && refresh_token) {
+          try {
+            await supabase.auth.setSession({
+              access_token,
+              refresh_token,
+            });
+          } catch (error) {
+            console.error('세션 복구 실패', error);
+          }
+        }
+      };
+
+      restoreSession();
+    }, []);
+  };
+
+  return { useAuthSession };
+}

--- a/src/hooks/useAuthCookies.ts
+++ b/src/hooks/useAuthCookies.ts
@@ -1,0 +1,15 @@
+import { useCookies } from 'react-cookie';
+
+export default function useAuthCookies() {
+  const [, setCookie] = useCookies();
+
+  const setCookies = (key: string, value: string, maxAge?: number) => {
+    setCookie(key, value, {
+      path: '/',
+      secure: true,
+      maxAge,
+    });
+  };
+
+  return { setCookies };
+}

--- a/src/hooks/useAuthCookies.ts
+++ b/src/hooks/useAuthCookies.ts
@@ -3,7 +3,7 @@ import { useCookies } from 'react-cookie';
 export default function useAuthCookies() {
   const [, setCookie] = useCookies();
 
-  const setCookies = (key: string, value: string, maxAge?: number) => {
+  const setCookies = (key: string, value: string, maxAge: number) => {
     setCookie(key, value, {
       path: '/',
       secure: true,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 
+import App from './App.tsx';
 import LoginPage from './pages/auth/Login.tsx';
 import SignUpPage from './pages/auth/SignUp.tsx';
 import HomePage from './pages/Home.tsx';
@@ -14,7 +15,8 @@ import { store } from './store/store.ts';
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <HomePage />,
+    element: <App />,
+    children: [{ index: true, element: <HomePage /> }],
   },
   {
     path: '/signup',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import './index.css';
 
+import { CookiesProvider } from 'react-cookie';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
@@ -26,8 +27,10 @@ const router = createBrowserRouter([
 ]);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <Provider store={store}>
-    <RouterProvider router={router} />
-    <ToastContainer />
-  </Provider>,
+  <CookiesProvider>
+    <Provider store={store}>
+      <RouterProvider router={router} />
+      <ToastContainer />
+    </Provider>
+  </CookiesProvider>,
 );

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -4,7 +4,9 @@ import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 import {
+  ACCESS_TOKEN,
   LOGIN_ERROR_MESSAGE,
+  REFRESH_TOKEN,
   REFRESH_TOKEN_EXPIRES_IN,
 } from '@/constants/auth.constants';
 import { TOAST_OPTION } from '@/constants/toast.constants';
@@ -51,9 +53,9 @@ const LoginPage = () => {
       console.log(session, user);
 
       if (session && user) {
-        setCookies('access_token', session.access_token, session.expires_in);
+        setCookies(ACCESS_TOKEN, session.access_token, session.expires_in);
         setCookies(
-          'refresh_token',
+          REFRESH_TOKEN,
           session.refresh_token,
           REFRESH_TOKEN_EXPIRES_IN,
         );

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify';
 
 import { LOGIN_ERROR_MESSAGE } from '@/constants/auth.constants';
 import { TOAST_OPTION } from '@/constants/toast.constants';
+import useAuthCookies from '@/hooks/useAuthCookies';
 import { useLoginMutation } from '@/services/authApi';
 
 import type { LoginForm } from '@/types/auth.types';
@@ -23,6 +24,7 @@ const LoginPage = () => {
   } = useForm<LoginForm>({ mode: 'onChange' });
   const [login, { isLoading }] = useLoginMutation();
   const navigate = useNavigate();
+  const { setCookies } = useAuthCookies();
 
   // 로그인 실패 처리
   const handleLoginError = (error: unknown) => {
@@ -43,7 +45,11 @@ const LoginPage = () => {
     try {
       const { session, user } = await login(formData).unwrap();
 
+      console.log(session, user);
+
       if (session && user) {
+        setCookies('access_token', session.access_token, session.expires_in);
+        setCookies('refresh_token', session.refresh_token);
         navigate('/posts');
       }
     } catch (error) {

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -3,7 +3,10 @@ import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
-import { LOGIN_ERROR_MESSAGE } from '@/constants/auth.constants';
+import {
+  LOGIN_ERROR_MESSAGE,
+  REFRESH_TOKEN_EXPIRES_IN,
+} from '@/constants/auth.constants';
 import { TOAST_OPTION } from '@/constants/toast.constants';
 import useAuthCookies from '@/hooks/useAuthCookies';
 import { useLoginMutation } from '@/services/authApi';
@@ -49,7 +52,11 @@ const LoginPage = () => {
 
       if (session && user) {
         setCookies('access_token', session.access_token, session.expires_in);
-        setCookies('refresh_token', session.refresh_token);
+        setCookies(
+          'refresh_token',
+          session.refresh_token,
+          REFRESH_TOKEN_EXPIRES_IN,
+        );
         navigate('/posts');
       }
     } catch (error) {

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -2,14 +2,18 @@ import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import supabase from '@/utils/supabase';
 
-import type { LoginForm } from '@/types/auth.types';
+import type {
+  LoginForm,
+  LoginResponse,
+  SignupResponse,
+} from '@/types/auth.types';
 import { type SignUpForm } from '@/types/auth.types';
 
 export const authApi = createApi({
   reducerPath: 'authApi',
   baseQuery: fakeBaseQuery(),
   endpoints: (builder) => ({
-    signUp: builder.mutation<any, SignUpForm>({
+    signUp: builder.mutation<SignupResponse, SignUpForm>({
       async queryFn({ email, password }) {
         const { data, error } = await supabase.auth.signUp({ email, password });
         if (error) {
@@ -24,7 +28,7 @@ export const authApi = createApi({
         return { data };
       },
     }),
-    login: builder.mutation<any, LoginForm>({
+    login: builder.mutation<LoginResponse, LoginForm>({
       async queryFn({ email, password }) {
         const { data, error } = await supabase.auth.signInWithPassword({
           email,

--- a/src/services/baseQueryWithReauth.ts
+++ b/src/services/baseQueryWithReauth.ts
@@ -1,0 +1,60 @@
+import {
+  ACCESS_TOKEN,
+  REFRESH_TOKEN,
+  REFRESH_TOKEN_EXPIRES_IN,
+} from '@/constants/auth.constants';
+import type { BaseQueryFn } from '@reduxjs/toolkit/query';
+import { fetchBaseQuery } from '@reduxjs/toolkit/query';
+import Cookies from 'js-cookie';
+
+import supabase from '@/utils/supabase';
+
+const baseQuery = fetchBaseQuery({
+  baseUrl: import.meta.env.VITE_SUPABASE_URL,
+  prepareHeaders: (headers) => {
+    const token = Cookies.get(ACCESS_TOKEN);
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    return headers;
+  },
+});
+
+const baseQueryWithReauth: BaseQueryFn = async (args, api, extraOptions) => {
+  let result = await baseQuery(args, api, extraOptions);
+
+  if (result.error && result.error.status === 401) {
+    console.warn('access token 만료, refresh 시도');
+    // try to get a new token
+    const { data } = await supabase.auth.refreshSession();
+    if (data.session) {
+      // store the new token
+      const { access_token, refresh_token, expires_in } = data.session;
+
+      Cookies.set(ACCESS_TOKEN, access_token, {
+        path: '/',
+        secure: true,
+        maxAge: expires_in,
+      });
+
+      Cookies.set(REFRESH_TOKEN, refresh_token, {
+        path: '/',
+        secure: true,
+        maxAge: REFRESH_TOKEN_EXPIRES_IN,
+      });
+
+      // retry the initial query
+      result = await baseQuery(args, api, extraOptions);
+    } else {
+      console.error('Failed to refresh session');
+      Cookies.remove(ACCESS_TOKEN);
+      Cookies.remove(REFRESH_TOKEN);
+      window.location.href = '/login';
+    }
+  }
+
+  return result;
+};
+
+export default baseQueryWithReauth;

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -1,5 +1,7 @@
 import type { FieldErrors, Path, UseFormRegister } from 'react-hook-form';
 
+import type { Session, User } from '@supabase/supabase-js';
+
 // 인증 관련 폼에서 공통으로 사용하는 필드 (로그인, 회원가입 모두 사용)
 export type AuthFormFields = {
   email: string;
@@ -23,3 +25,10 @@ export interface AuthFormInputProps<T extends Record<string, any>> {
   errors: FieldErrors<T>;
   name: Path<T>;
 }
+
+export type SignupResponse = {
+  user: User | null;
+  session: Session | null;
+};
+
+export type LoginResponse = SignupResponse;

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -2,6 +2,11 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseKey);
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+  },
+});
 
 export default supabase;

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,6 +634,14 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
+"@types/hoist-non-react-statics@^3.3.6":
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz#6bba74383cdab98e8db4e20ce5b4a6b98caed010"
+  integrity sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@^7.0.11":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -672,6 +680,13 @@
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
   integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
+
+"@types/react@*":
+  version "19.0.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.12.tgz#338b3f7854adbb784be454b3a83053127af96bd3"
+  integrity sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==
+  dependencies:
+    csstype "^3.0.2"
 
 "@types/react@^18.3.20":
   version "18.3.20"
@@ -1129,6 +1144,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -1929,6 +1949,13 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -2689,6 +2716,15 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-cookie@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-8.0.1.tgz#0d7f5112c9003b61c70d3d53f1f0a5b741e9f2e9"
+  integrity sha512-QNdAd0MLuAiDiLcDU/2s/eyKmmfMHtjPUKJ2dZ/5CcQ9QKUium4B3o61/haq6PQl/YWFqC5PO8GvxeHKhy3GFA==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.6"
+    hoist-non-react-statics "^3.3.2"
+    universal-cookie "^8.0.0"
+
 react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -2702,7 +2738,7 @@ react-hook-form@^7.54.2:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
   integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3333,6 +3369,13 @@ undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+universal-cookie@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-8.0.1.tgz#19263fcda6889978a081c610a90fc395eeaeec64"
+  integrity sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==
+  dependencies:
+    cookie "^1.0.2"
 
 update-browserslist-db@^1.1.1:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,11 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/json-schema@^7.0.11":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -2230,6 +2235,11 @@ jiti@^1.21.6:
   version "1.21.7"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
+
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 변경 사항
- 로그인/회원가입 시 access_token, refresh_token 쿠키 저장 (로컬 스토리지 저장 옵션 false)
- 앱 진입 시 setSession을 통한 세션 복원
- access token 만료 시 refresh token으로 자동 갱신
- rtk query 요청 중 401 에러 발생 시 refresh 갱신 및 재요청 처리