### PR TITLE
fix: useGetPostsQuery 정렬 변경 시 refetch 안 되는 버그 수정

### DIFF
--- a/src/components/post/SearchSortBox.tsx
+++ b/src/components/post/SearchSortBox.tsx
@@ -17,7 +17,12 @@ const SearchSortBox = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [keyword, setKeyword] = useState<string>('');
   const [sortId, setSortId] = useState<string>('created_at.desc');
-  const { data } = useGetPostsQuery({ keyword, sort: sortId });
+  const { data } = useGetPostsQuery(
+    { keyword, sort: sortId },
+    {
+      refetchOnMountOrArgChange: true,
+    },
+  );
 
   const handleSearchKeyword: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -30,7 +35,7 @@ const SearchSortBox = () => {
 
   useEffect(() => {
     dispatch(setPosts(data || []));
-  }, [data]);
+  }, [data, dispatch]);
 
   return (
     <div className='mt-3 flex items-center justify-end gap-2'>

--- a/src/services/postApi.ts
+++ b/src/services/postApi.ts
@@ -22,14 +22,17 @@ export const postApi = createApi({
     getPosts: builder.query<PostItem[], GetPostsParams | void>({
       query: (params) => {
         const keyword = params?.keyword || '';
-        const sort = params?.sort || 'created_at.desc';
+        const sort = encodeURIComponent(params?.sort || 'created_at.desc');
 
         const searchQuery = keyword
           ? `title=ilike.*${encodeURIComponent(keyword)}*&`
           : '';
 
-        return `/posts?${searchQuery}order=${sort}`;
+        return {
+          url: `/posts?${searchQuery}order=${sort}`,
+        };
       },
+      keepUnusedDataFor: 0,
     }),
 
     // 게시글 상세 조회 API


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 변경 사항
- useGetPostsQuery에 refetchOnMountOrArgChange 옵션 추가
- keepUnusedDataFor 설정으로 쿼리 캐시 무효화 타이밍 조정

